### PR TITLE
feat: track multiple targets @ trackers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.3-track-multiple-targets.1",
+  "version": "2.0.3-track-multiple-targets.2",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.2",
+  "version": "2.0.3-track-multiple-targets.0",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.3-track-multiple-targets.2",
+  "version": "2.0.3-track-multiple-targets.3",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.3-track-multiple-targets.0",
+  "version": "2.0.3-track-multiple-targets.1",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15102,7 +15102,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.0.3-track-multiple-targets.1",
+      "version": "2.0.3-track-multiple-targets.2",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15043,10 +15043,10 @@
     },
     "packages/fw-avatar": {
       "name": "@fw-components/fw-avatar",
-      "version": "2.0.2",
+      "version": "2.0.3-track-multiple-targets.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.0.2",
+        "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-list": "^0.25.3",
         "@material/mwc-menu": "^0.25.3",
@@ -15065,10 +15065,10 @@
     },
     "packages/fw-dnd": {
       "name": "@fw-components/fw-dnd",
-      "version": "2.0.2",
+      "version": "2.0.3-track-multiple-targets.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.0.2",
+        "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-button": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",
@@ -15078,7 +15078,7 @@
     },
     "packages/styles": {
       "name": "@fw-components/styles",
-      "version": "2.0.2",
+      "version": "2.0.3-track-multiple-targets.0",
       "license": "ISC",
       "dependencies": {
         "lit": "^2.1.2"
@@ -15102,7 +15102,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.0.2",
+      "version": "2.0.3-track-multiple-targets.0",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"
@@ -16483,7 +16483,7 @@
     "@fw-components/fw-avatar": {
       "version": "file:packages/fw-avatar",
       "requires": {
-        "@fw-components/styles": "^2.0.2",
+        "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-list": "^0.25.3",
         "@material/mwc-menu": "^0.25.3",
@@ -16501,7 +16501,7 @@
     "@fw-components/fw-dnd": {
       "version": "file:packages/fw-dnd",
       "requires": {
-        "@fw-components/styles": "^2.0.2",
+        "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-button": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15102,7 +15102,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.0.3-track-multiple-targets.2",
+      "version": "2.0.3-track-multiple-targets.3",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15102,7 +15102,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.0.3-track-multiple-targets.0",
+      "version": "2.0.3-track-multiple-targets.1",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"

--- a/packages/fw-avatar/package.json
+++ b/packages/fw-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-avatar",
-  "version": "2.0.2",
+  "version": "2.0.3-track-multiple-targets.0",
   "description": "Avatar Web Component",
   "main": "src/fw-avatar.js",
   "type": "module",
@@ -15,7 +15,7 @@
     "test:watch": "web-test-runner  --watch"
   },
   "dependencies": {
-    "@fw-components/styles": "^2.0.2",
+    "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
     "@material/mwc-icon": "^0.27.0",
     "@material/mwc-list": "^0.25.3",
     "@material/mwc-menu": "^0.25.3",

--- a/packages/fw-dnd/package.json
+++ b/packages/fw-dnd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-dnd",
-  "version": "2.0.2",
+  "version": "2.0.3-track-multiple-targets.0",
   "description": "Drag-n-drop list",
   "main": "fw-dnd.js",
   "publishConfig": {
@@ -12,7 +12,7 @@
   "author": "The Fundwave Authors",
   "license": "ISC",
   "dependencies": {
-    "@fw-components/styles": "^2.0.2",
+    "@fw-components/styles": "^2.0.3-track-multiple-targets.0",
     "@polymer/iron-icons": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-icon-button": "^3.0.2",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/styles",
-  "version": "2.0.2",
+  "version": "2.0.3-track-multiple-targets.0",
   "description": "Style library for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/README.md
+++ b/packages/trackers/README.md
@@ -34,3 +34,12 @@ const tracker = new Trackers({
 
 tracker.initialize();
 ```
+
+### Note: 
+tracking multiple targets is also supported. Use `:nth-child(+)` identifier to highlight elements whose multiple instances are to be tracked
+
+> Supported selector
+  > ```js
+  > document.querySelector("div > div.main-content > div.page > route-page > request-grid:nth-child(+)")
+  >  ```
+

--- a/packages/trackers/lib/index.ts
+++ b/packages/trackers/lib/index.ts
@@ -69,7 +69,7 @@ export class Trackers {
       const elements = tree.destinations;
       this.#debug("Attempting registration of trackers @ ", { tree, config: eventConfig });
 
-      if (!elements?.length) tree.parents.forEach((root) => this.observeNode(root));
+      if (!elements?.length) tree.parents.sort().reverse().forEach((root) => this.observeNode(root));
       if (!tree.parents.length) this.#debug("No shadow-roots retrieved for observation", { eventConfig });
 
       if (!elements?.length || !eventConfig.title) return;
@@ -110,7 +110,7 @@ export class Trackers {
     if (!Boolean(node)) return;
 
     try {
-      this.observer?.observe(node!, { subtree: true, attributes: true, childList: true });
+      this.observer?.observe((node! as Element).shadowRoot || node!, { subtree: true, attributes: true, childList: true });
       this.#debug("Registering observer on target: ", (node as ShadowRoot)?.host || node);
     } catch (error) {
       this.#debug("Failed to register observer on target: ", { error, node: (node as ShadowRoot)!.host || node });

--- a/packages/trackers/lib/index.ts
+++ b/packages/trackers/lib/index.ts
@@ -70,6 +70,7 @@ export class Trackers {
       this.#debug("Attempting registration of trackers @ ", { tree, config: eventConfig });
 
       if (!elements?.length) tree.shadowRoots.forEach((root) => this.observeNode(root));
+      if (!tree.shadowRoots.length) this.#debug("No shadow-roots retreived for observation", { eventConfig });
 
       if (!elements?.length || !eventConfig.title) return;
 

--- a/packages/trackers/lib/index.ts
+++ b/packages/trackers/lib/index.ts
@@ -69,7 +69,7 @@ export class Trackers {
       const elements = tree.destinations;
       this.#debug("Attempting registration of trackers @ ", { tree, config: eventConfig });
 
-      if (!elements?.length) tree.parents.sort().reverse().forEach((root) => this.observeNode(root));
+      if (!elements?.length) tree.parents.reverse().forEach((root) => this.observeNode(root));
       if (!tree.parents.length) this.#debug("No shadow-roots retrieved for observation", { eventConfig });
 
       if (!elements?.length || !eventConfig.title) return;

--- a/packages/trackers/lib/index.ts
+++ b/packages/trackers/lib/index.ts
@@ -69,8 +69,8 @@ export class Trackers {
       const elements = tree.destinations;
       this.#debug("Attempting registration of trackers @ ", { tree, config: eventConfig });
 
-      if (!elements?.length) tree.shadowRoots.forEach((root) => this.observeNode(root));
-      if (!tree.shadowRoots.length) this.#debug("No shadow-roots retreived for observation", { eventConfig });
+      if (!elements?.length) tree.parents.forEach((root) => this.observeNode(root));
+      if (!tree.parents.length) this.#debug("No shadow-roots retrieved for observation", { eventConfig });
 
       if (!elements?.length || !eventConfig.title) return;
 
@@ -106,14 +106,14 @@ export class Trackers {
    * attaches mutation-observer to provided node
    * @param {ShadowRoot | null} node - ShadowRoot to attach the observer to
    */
-  observeNode(node: ShadowRoot | null) {
+  observeNode(node: Element | ShadowRoot | null) {
     if (!Boolean(node)) return;
 
     try {
       this.observer?.observe(node!, { subtree: true, attributes: true, childList: true });
-      this.#debug("Registering observer on target: ", node?.host || node);
+      this.#debug("Registering observer on target: ", (node as ShadowRoot)?.host || node);
     } catch (error) {
-      this.#debug("Failed to register observer on target: ", { error, node: node!.host || node });
+      this.#debug("Failed to register observer on target: ", { error, node: (node as ShadowRoot)!.host || node });
     }
   }
 

--- a/packages/trackers/lib/utils/constants.ts
+++ b/packages/trackers/lib/utils/constants.ts
@@ -1,1 +1,2 @@
 export const SHADOW_ROOT_IDENTIFIER = ">>>";
+export const MULTIPLE_TARGETS_IDENTIFIER = ":nth-child(+)"; // invalid notation

--- a/packages/trackers/lib/utils/index.ts
+++ b/packages/trackers/lib/utils/index.ts
@@ -90,7 +90,7 @@ export function getNodeTree(selector: string, context: Document | ShadowRoot | E
     if (!path.includes(MULTIPLE_TARGETS_IDENTIFIER)) return result.push({ path, needsMultiple: false });
 
     const selectorsWithinMultipleParents = path.split(MULTIPLE_TARGETS_IDENTIFIER);
-    result.push(...selectorsWithinMultipleParents.map((path) => ({ path: path.replace(/^\s*/, "").replace(/^[^\w]+/, ""), needsMultiple: true })).filter((path) => path.path));
+    result.push(...selectorsWithinMultipleParents.map((path) => ({ path: path.replace(/^\s*/, "").replace(/^\s*\>*\s*/, ""), needsMultiple: true })).filter((path) => path.path));
   });
 
   const nodeTreeContext = { destinations: null as Array<Element> | null, context: [context], parents: [] as Array<ShadowRoot | Element> };

--- a/packages/trackers/lib/utils/index.ts
+++ b/packages/trackers/lib/utils/index.ts
@@ -8,7 +8,7 @@ import { MULTIPLE_TARGETS_IDENTIFIER, SHADOW_ROOT_IDENTIFIER } from "./constants
  */
 export function getElementsFromSelector(selector: string = "", context: Document | DocumentFragment | Element | null = document): Element[] | null {
   if (!context?.querySelector) {
-    console.warn("Provided context doesn't provide `querySelector` handler");
+    console.warn("Provided context doesn't provide `querySelector` handler", { context, selector });
     return null;
   }
 

--- a/packages/trackers/lib/utils/index.ts
+++ b/packages/trackers/lib/utils/index.ts
@@ -78,23 +78,22 @@ export function matchPathPattern(path: string | string[], pattern: string | stri
 
 /**
  * retrieves the DOM-element for the provided selector, along with all of it's parent shadowRoots
- * @param {string} selector - css-selector 
- * @param {Document | ShadowRoot | null} context - context from where to start tree-traversal 
- * @returns {{ destination: Element | null, context: Document | ShadowRoot, shadowRoots: ShadowRoot[] }}
+ * @param {string} selector - css-selector
+ * @param {Document | ShadowRoot | null} context - context from where to start tree-traversal
+ * @returns {{ destinations: Element[] | null, context: Document | ShadowRoot, shadowRoots: ShadowRoot[] }}
  */
 export function getNodeTree(selector: string, context: Document | ShadowRoot) {
-  const tree = selector.split(SHADOW_ROOT_IDENTIFIER);
+  const nodeTreeContext = { destinations: null as Element[] | null, context, shadowRoots: [] as ShadowRoot[] };
 
-  const nodeTreeContext = { destination: null as Element | null, context, shadowRoots: [] as ShadowRoot[] };
+  const targets = getElementsFromSelector(selector, nodeTreeContext.context);
+  if (!targets) return nodeTreeContext;
 
-  for (selector of tree) {
-    const element = getElementFromSelector(selector, nodeTreeContext.context);
-    if (!element) return nodeTreeContext;
-
-    if (element.shadowRoot) nodeTreeContext.shadowRoots.push(element.shadowRoot);
-    if (tree.indexOf(selector) === tree.length - 1) nodeTreeContext.destination = element;
-    if (element.shadowRoot) nodeTreeContext.context = element.shadowRoot;
+  const element = targets[0];
+  if (element?.shadowRoot && !(targets.length > 1)) {
+    nodeTreeContext.shadowRoots.push(element.shadowRoot);
+    nodeTreeContext.context = element.shadowRoot;
   }
+  nodeTreeContext.destinations = targets;
 
   return nodeTreeContext;
 }

--- a/packages/trackers/lib/utils/index.ts
+++ b/packages/trackers/lib/utils/index.ts
@@ -1,7 +1,7 @@
 import { MULTIPLE_TARGETS_IDENTIFIER, SHADOW_ROOT_IDENTIFIER } from "./constants.js";
 
 /**
- * retrieves an element for a provided selector
+ * retrieves multiple elements for a provided selector
  * @param {string} selector - css-selector
  * @param {Document | ShadowRoot | null} context - context from where to start tree-traversal
  * @returns {Element[] | null}

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.0.3-track-multiple-targets.1",
+  "version": "2.0.3-track-multiple-targets.2",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.0.3-track-multiple-targets.2",
+  "version": "2.0.3-track-multiple-targets.3",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.0.2",
+  "version": "2.0.3-track-multiple-targets.0",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.0.3-track-multiple-targets.0",
+  "version": "2.0.3-track-multiple-targets.1",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR adds support for tracking multiple target from a single js-path @ fw/trackers

This is achieved now by adding a custom-selector `:nth-child(+)` which allows for users to track multiple targets or nested targets within multiple parents

Usage:
- Now track all div's with class `row`
  ```js
  document.querySelector("div > div.main-content > div.row:nth-child(+)")
  ```
- Tracking multiple targets
  ```js
  document.querySelector("div > div.main-content > div.page > route-page > request-grid:nth-child(+)")
  ```
- Tracking multiple targets (within shadow-roots)
  ```js
  document.querySelector("div > div.main-content > div.page > route-page").shadowRoot
    .querySelector("request-overview").shadowRoot
    .querySelector("div > div > div > request-grid:nth-child(+)")
  ```
- Tracking specific children under multiple targets
  ```js
  document.querySelector("div > div.main-content > div.page > route-page").shadowRoot
    .querySelector("request-overview").shadowRoot
    .querySelector("div > div > div > request-grid:nth-child(+) > div:nth-child(2) > mwc-icon.mail")
  ```
- Works recursively so it can capture & track children under multiple targets which are children of multiple targets
  ```js
  document.querySelector("div > div.main-content > div.page > route-page").shadowRoot
    .querySelector("request-overview").shadowRoot
    .querySelector("div > div > div > request-grid:nth-child(+)").shadowRoot
    .querySelector("div > div.request-card-wrapper:nth-child(+) > div:nth-child(2) > mwc-icon.mail")
  ```