### PR TITLE
fix: handle root-path comparison @ trackers#matchPathPattern

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.3",
+  "version": "2.0.4-fix-match-path-pattern.0",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15043,10 +15043,10 @@
     },
     "packages/fw-avatar": {
       "name": "@fw-components/fw-avatar",
-      "version": "2.0.3",
+      "version": "2.0.4-fix-match-path-pattern.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.0.3",
+        "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-list": "^0.25.3",
         "@material/mwc-menu": "^0.25.3",
@@ -15065,10 +15065,10 @@
     },
     "packages/fw-dnd": {
       "name": "@fw-components/fw-dnd",
-      "version": "2.0.3",
+      "version": "2.0.4-fix-match-path-pattern.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.0.3",
+        "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-button": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",
@@ -15078,7 +15078,7 @@
     },
     "packages/styles": {
       "name": "@fw-components/styles",
-      "version": "2.0.3",
+      "version": "2.0.4-fix-match-path-pattern.0",
       "license": "ISC",
       "dependencies": {
         "lit": "^2.1.2"
@@ -15102,7 +15102,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.0.3",
+      "version": "2.0.4-fix-match-path-pattern.0",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"
@@ -16483,7 +16483,7 @@
     "@fw-components/fw-avatar": {
       "version": "file:packages/fw-avatar",
       "requires": {
-        "@fw-components/styles": "^2.0.3",
+        "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-list": "^0.25.3",
         "@material/mwc-menu": "^0.25.3",
@@ -16501,7 +16501,7 @@
     "@fw-components/fw-dnd": {
       "version": "file:packages/fw-dnd",
       "requires": {
-        "@fw-components/styles": "^2.0.3",
+        "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-button": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",

--- a/packages/fw-avatar/package.json
+++ b/packages/fw-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-avatar",
-  "version": "2.0.3",
+  "version": "2.0.4-fix-match-path-pattern.0",
   "description": "Avatar Web Component",
   "main": "src/fw-avatar.js",
   "type": "module",
@@ -15,7 +15,7 @@
     "test:watch": "web-test-runner  --watch"
   },
   "dependencies": {
-    "@fw-components/styles": "^2.0.3",
+    "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
     "@material/mwc-icon": "^0.27.0",
     "@material/mwc-list": "^0.25.3",
     "@material/mwc-menu": "^0.25.3",

--- a/packages/fw-dnd/package.json
+++ b/packages/fw-dnd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-dnd",
-  "version": "2.0.3",
+  "version": "2.0.4-fix-match-path-pattern.0",
   "description": "Drag-n-drop list",
   "main": "fw-dnd.js",
   "publishConfig": {
@@ -12,7 +12,7 @@
   "author": "The Fundwave Authors",
   "license": "ISC",
   "dependencies": {
-    "@fw-components/styles": "^2.0.3",
+    "@fw-components/styles": "^2.0.4-fix-match-path-pattern.0",
     "@polymer/iron-icons": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-icon-button": "^3.0.2",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/styles",
-  "version": "2.0.3",
+  "version": "2.0.4-fix-match-path-pattern.0",
   "description": "Style library for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/lib/utils/index.ts
+++ b/packages/trackers/lib/utils/index.ts
@@ -60,6 +60,7 @@ export function getSelectorForShadowRootJsPath(jsPath: string = "") {
  * @returns {boolean}
  **/
 export function matchPathPattern(path: string | string[], pattern: string | string[]): boolean {
+  if (path.toString() === "/" && pattern.toString() === "/") return true;
   if (!Array.isArray(path)) path = path.split("/").filter(Boolean);
   if (!Array.isArray(pattern)) pattern = pattern.split("/").filter(Boolean);
 

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.0.3",
+  "version": "2.0.4-fix-match-path-pattern.0",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
the matchPathPattern method failed to equate path '/' to pattern '/'

works fine for other cases but split based on '/' resulted in empty arrays which resulted in false returns