### PR TITLE
fix: formula input loosing focus in safari + enhancements in parsing formula string

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.5",
+  "version": "2.0.7-formula-editor-enhancements.6",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.1",
+  "version": "2.0.7-formula-editor-enhancements.2",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor.20",
+  "version": "2.0.7-formula-editor-enhancements.0",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.11",
+  "version": "2.0.7-formula-editor-enhancements.12",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.4",
+  "version": "2.0.7-formula-editor-enhancements.5",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.9",
+  "version": "2.0.7-formula-editor-enhancements.10",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.0",
+  "version": "2.0.7-formula-editor-enhancements.1",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.3",
+  "version": "2.0.7-formula-editor-enhancements.4",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.8",
+  "version": "2.0.7-formula-editor-enhancements.9",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.2",
+  "version": "2.0.7-formula-editor-enhancements.3",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.10",
+  "version": "2.0.7-formula-editor-enhancements.11",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.7",
+  "version": "2.0.7-formula-editor-enhancements.8",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.7-formula-editor-enhancements.6",
+  "version": "2.0.7-formula-editor-enhancements.7",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.1",
+      "version": "2.0.7-formula-editor-enhancements.2",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor.20",
+      "version": "2.0.7-formula-editor-enhancements.0",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.4",
+      "version": "2.0.7-formula-editor-enhancements.5",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.7",
+      "version": "2.0.7-formula-editor-enhancements.8",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.10",
+      "version": "2.0.7-formula-editor-enhancements.11",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.2",
+      "version": "2.0.7-formula-editor-enhancements.3",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.3",
+      "version": "2.0.7-formula-editor-enhancements.4",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.8",
+      "version": "2.0.7-formula-editor-enhancements.9",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.5",
+      "version": "2.0.7-formula-editor-enhancements.6",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.6",
+      "version": "2.0.7-formula-editor-enhancements.7",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.9",
+      "version": "2.0.7-formula-editor-enhancements.10",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.11",
+      "version": "2.0.7-formula-editor-enhancements.12",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17909,7 +17909,7 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.0.7-formula-editor-enhancements.0",
+      "version": "2.0.7-formula-editor-enhancements.1",
       "license": "ISC",
       "dependencies": {
         "@fw-components/styles": "^2.0.7-formula-editor.0",

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor.20",
+  "version": "2.0.7-formula-editor-enhancements.0",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.10",
+  "version": "2.0.7-formula-editor-enhancements.11",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.9",
+  "version": "2.0.7-formula-editor-enhancements.10",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.6",
+  "version": "2.0.7-formula-editor-enhancements.7",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.0",
+  "version": "2.0.7-formula-editor-enhancements.1",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.1",
+  "version": "2.0.7-formula-editor-enhancements.2",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.3",
+  "version": "2.0.7-formula-editor-enhancements.4",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.8",
+  "version": "2.0.7-formula-editor-enhancements.9",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.11",
+  "version": "2.0.7-formula-editor-enhancements.12",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.5",
+  "version": "2.0.7-formula-editor-enhancements.6",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.7",
+  "version": "2.0.7-formula-editor-enhancements.8",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.4",
+  "version": "2.0.7-formula-editor-enhancements.5",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.0.7-formula-editor-enhancements.2",
+  "version": "2.0.7-formula-editor-enhancements.3",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-builder.js",
   "publishConfig": {

--- a/packages/formula-editor/src/formula-editor.ts
+++ b/packages/formula-editor/src/formula-editor.ts
@@ -130,7 +130,7 @@ export class FormulaEditor extends LitElement {
       this.parseInput(this._recommendations[0]);
     }
     else if (event.code === "ArrowDown" || event.code === "ArrowUp") {
-      event.preventDefault();
+      if(this._recommendations) event.preventDefault();
       this.navigateRecommendations(event.code);
       this.requestUpdate();
     }

--- a/packages/formula-editor/src/formula-editor.ts
+++ b/packages/formula-editor/src/formula-editor.ts
@@ -162,7 +162,7 @@ export class FormulaEditor extends LitElement {
 
     if(!this.content) editor.style.height = "var(--fe-height, 30px)";
    
-    if(editor.scrollHeight > editor.clientHeight) editor.style.height = (editor.scrollHeight)+"px"
+    if(editor.scrollHeight > editor.clientHeight) editor.style.height = (editor.scrollHeight + 5)+"px"
   }
 
   /**

--- a/packages/formula-editor/src/formula-editor.ts
+++ b/packages/formula-editor/src/formula-editor.ts
@@ -299,6 +299,7 @@ export class FormulaEditor extends LitElement {
         <textarea
           placeholder=${this.placeholder}
           id="wysiwyg-editor"
+          class=${this.errorString?.length ? "error" : ""}
           .value=${this.content}
           @keydown=${this.handleKeyboardEvents}
           @blur=${this.handleFocusOut}

--- a/packages/formula-editor/src/formula-editor.ts
+++ b/packages/formula-editor/src/formula-editor.ts
@@ -14,11 +14,15 @@ export class FormulaEditor extends LitElement {
     this._parser = new Parser(this.variables, this.minSuggestionLen);
   }
 
-  protected firstUpdated(
-    _changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
-  ): void {
+  protected firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
     this._parser = new Parser(this.variables, this.minSuggestionLen);
-    this.parseInput(null, false);
+
+    let editor : HTMLElement = this.shadowRoot?.getElementById("wysiwyg-editor");
+
+    const inputListener = this.handleContentUpdate.bind(this);
+    editor.addEventListener("input", inputListener);
+
+    editor.focus();
   }
 
   /**
@@ -49,7 +53,7 @@ export class FormulaEditor extends LitElement {
   currentCursorRect: DOMRect | undefined = undefined;
 
   @state()
-  lastInputType: string = "undef";
+  lastInputType: string = "";
 
   @state()
   _selectedRecommendation: string; 
@@ -88,17 +92,7 @@ export class FormulaEditor extends LitElement {
   errorString: string | null = null;
 
   @query("wysiwyg-editor")
-  editor: any;
-
-  handleChange(event: InputEvent) {
-    event.preventDefault();
-
-    this.lastInputType = event.inputType;
-    this.content = (event.target as HTMLDivElement).innerText;
-    this.parseInput();
-
-    (event.target as HTMLDivElement).focus();
-  }
+  editor: HTMLTextAreaElement;
 
   navigateRecommendations(direction: string) {
     if (!this._recommendations) return;
@@ -153,7 +147,22 @@ export class FormulaEditor extends LitElement {
     if (!editor) return;
 
     this.parseInput(recommendation);
-    this.currentCursorPosition = null;
+  }
+
+  handleContentUpdate(event: any) {
+    event.preventDefault(); 
+
+    this.lastInputType = event.inputType;
+    this.content = event.target.value;
+    this.parseInput();
+  }
+
+  _adjustInputHeight() {
+    const editor = this.shadowRoot?.getElementById("wysiwyg-editor");
+
+    if(!this.content) editor.style.height = "var(--fe-height, 30px)";
+   
+    if(editor.scrollHeight > editor.clientHeight) editor.style.height = (editor.scrollHeight)+"px"
   }
 
   /**
@@ -164,21 +173,12 @@ export class FormulaEditor extends LitElement {
    * needed when manual insertion of text is required (eg: during initialization)
    * @returns void
    */
-  parseInput(
-    recommendation: string | null = null,
-    manageCursor: boolean = true
-  ) {
-    let editor = this.shadowRoot?.getElementById("wysiwyg-editor");
+  parseInput(recommendation: string | null = null) {
+    let editor = <HTMLTextAreaElement>this.shadowRoot?.getElementById("wysiwyg-editor");
+
     if (!editor) return;
 
-    /**
-     * @see https://github.com/WICG/webcomponents/issues/79
-     */
-
-    if (manageCursor)
-      this.currentCursorPosition = recommendation
-        ? this.currentCursorPosition
-        : Cursor.getCaretPosition(this.shadowRoot!, editor);
+    this.currentCursorPosition = editor.selectionStart;
 
     const parseOutput = this._parser.parseInput(
       this.content,
@@ -190,7 +190,6 @@ export class FormulaEditor extends LitElement {
     this._formattedContent = parseOutput.formattedContent;
     this.errorString = parseOutput.errorString;
 
-
     /**
      * Don't modify the text stream manually if the text is being composed,
      * unless the user manually chooses to do so by selecting a suggestion.
@@ -199,25 +198,20 @@ export class FormulaEditor extends LitElement {
      * @see https://bugs.chromium.org/p/chromium/issues/detail?id=689541
      * */
 
-    if (this.lastInputType != "insertCompositionText" || recommendation) {
-      editor.innerHTML = parseOutput.formattedString!;
+    if (this.lastInputType !== "insertCompositionText" || recommendation) {
+      const formattedString = parseOutput.formattedString!;
+      this.content = formattedString;
     }
-
-    this.content = (editor as HTMLDivElement).innerText;
 
     if (recommendation) {
       this._recommendations = null;
       this.currentCursorPosition = parseOutput.newCursorPosition;
+      
+      setTimeout(() => {
+        editor.setSelectionRange(this.currentCursorPosition, this.currentCursorPosition);
+      }, 0);
     }
 
-    if (manageCursor)
-      Cursor.setCaretPosition(this.currentCursorPosition!, editor);
-    editor?.focus();
-
-    if (manageCursor)
-      this.currentCursorRect = Cursor.getCursorRect(this.shadowRoot!);
-
-    this.requestUpdate();
 
     this.dispatchEvent(
       new CustomEvent("fw-formula-content-changed", {
@@ -229,6 +223,8 @@ export class FormulaEditor extends LitElement {
         bubbles: true,
       })
     );
+
+    editor.focus();
   }
 
   requestCalculate() {
@@ -264,25 +260,26 @@ export class FormulaEditor extends LitElement {
       if(!this.content.trim()){
         this._recommendations= Array.from(this.variables.keys());
       }
+
+      this._adjustInputHeight();
     }
 
     if(_changedProperties.has("variables")){
       this._parser = new Parser(this.variables, this.minSuggestionLen);
-      this.parseInput(null, false);
     }
 
   }
 
   handleFocusOut(e: FocusEvent) {
-      this.isFocus = false;
-      this._recommendations = null;
-      this.requestUpdate();
+    this.isFocus = false;
+    this._recommendations = null;
+    this.requestUpdate();
   }
 
   handleFocus(e: FocusEvent){
     this.isFocus = true;
     if(!this.content.trim()){
-      this._recommendations= Array.from(this.variables.keys());
+      this._recommendations = Array.from(this.variables.keys());
     }
   }
   
@@ -299,17 +296,14 @@ export class FormulaEditor extends LitElement {
             </label>`
           : ""}
         
-        <div
-          contenteditable
+        <textarea
           placeholder=${this.placeholder}
           id="wysiwyg-editor"
-          spellcheck="false"
-          autocomplete="off"
-          @input=${this.handleChange}
+          .value=${this.content}
           @keydown=${this.handleKeyboardEvents}
           @blur=${this.handleFocusOut}
           @focus=${this.handleFocus}
-        ></div>
+        ></textarea>
       ${this._recommendations && this.isFocus
         ? html` <suggestion-menu
               .recommendations=${this._recommendations}

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -140,7 +140,7 @@ export class Parser {
       if (expectation != Expectation.UNDEFINED) {
 
         if(this.mathematicalOperators.has(previousToken) && isOperator) {
-          parseOutput.errorString = `Unexpected same operator at position ${currentPosition}`;
+          parseOutput.errorString = `Multiple operators at position ${currentPosition}`;
           expectation = Expectation.UNDEFINED;
         }
 

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -162,7 +162,7 @@ export class Parser {
           token != "(" &&
           !(
             (token == "-" || token == "+") &&
-            (!currentTokens.trim() || this.mathematicalOperators.has(previousToken))
+            (!currentTokens.trim() || previousToken === "(" || this.mathematicalOperators.has(previousToken))
           )
         ) {
           parseOutput.errorString = `Expected variable/number at position ${currentPosition}`;
@@ -276,7 +276,7 @@ export class Parser {
     for (const token of tokens) {
       if (
         (token == "+" || token == "-") &&
-        (!currentTokens.trim() || this.mathematicalOperators.has(previousToken))
+        (!currentTokens.trim() || currentTokens.trim() === "(" || this.mathematicalOperators.has(previousToken))
       ) {
         carriedToken = token;
       } else if (carriedToken) {

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -356,6 +356,7 @@ export class Parser {
       // and can be directly put into the result stack.
 
       if (
+        ((symbol === "+" || symbol[0] === "-") && this.variables.has(symbol.substring(1))) || 
         this.variables.has(symbol) ||
         (!isNaN(parseFloat(symbol)) && isFinite(parseFloat(symbol)))
       ) {

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -109,16 +109,7 @@ export class Parser {
           // to a variable.
           isNumber = true;
 
-          if (this.mathematicalOperators.has(token)) {
-            // append recommendation at the end if token is an operator
-            const updatedTokenString = `${token} ${recommendation}`;
-            formattedString += updatedTokenString;
-            currentPosition += updatedTokenString.length;
-            parseOutput.newCursorPosition = currentPosition;
-
-            recommendation = null;
-            return;            
-          };
+          if (this.mathematicalOperators.has(token)) token += recommendation;    
 
           // If the new cursor length somehow becomes larger than the
           // length of the formula string, setting the caret to that

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -270,7 +270,7 @@ export class Parser {
     for (const token of tokens) {
       if (
         (token == "+" || token == "-") &&
-        (!currentTokens.trim() || currentTokens.trim() === "(" || this.mathematicalOperators.has(previousToken))
+        (!currentTokens.trim() || previousToken === "(" || this.mathematicalOperators.has(previousToken))
       ) {
         carriedToken = token;
       } else if (carriedToken) {

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -109,7 +109,16 @@ export class Parser {
           // to a variable.
           isNumber = true;
 
-          if (this.mathematicalOperators.has(token)) token += recommendation;    
+          if (this.mathematicalOperators.has(token)) {
+            // append recommendation at the end if token is an operator
+            const updatedTokenString = `${token} ${recommendation}`;
+            formattedString += updatedTokenString;
+            currentPosition += updatedTokenString.length;
+            parseOutput.newCursorPosition = currentPosition;
+
+            recommendation = null;
+            return;            
+          };
 
           // If the new cursor length somehow becomes larger than the
           // length of the formula string, setting the caret to that

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -84,7 +84,8 @@ export class Parser {
     tokens?.forEach((token) => {
       // It is a number is either it's in the defined variables, or
       // it's a valid number literal.
-      let isNumber = this.variables.has(token) || !Number.isNaN(Number(token));
+      
+      let isNumber = token.trim() !== "" && (this.variables.has(token) || !Number.isNaN(Number(token)));
       let isOperator = this.mathematicalOperators.has(token);
       let isSpace = token.trim() == "";
       let isBracket = token == "(" || token == ")";
@@ -118,9 +119,10 @@ export class Parser {
           recommendation = null;
         }
         if(!isSpace) parseOutput.recommendations = this._recommender.getRecommendation(token);
-        previousToken = isSpace ? previousToken : token;
+        
       }
       
+      previousToken = isSpace ? previousToken : token;
 
       let tokenClassName = "";
 
@@ -140,6 +142,7 @@ export class Parser {
         else if (
           expectation == Expectation.VARIABLE &&
           !isNumber &&
+          !isSpace && 
           token != "(" &&
           !(
             (token == "-" || token == "+") &&
@@ -156,6 +159,7 @@ export class Parser {
         else if (
           expectation == Expectation.OPERATOR &&
           !isOperator &&
+          !isSpace &&
           token != ")"
         ) {
           parseOutput.errorString = `Expected mathematical operator at position ${currentPosition}`;
@@ -164,7 +168,7 @@ export class Parser {
         }
 
         // Unknown symbol/variable/word
-        else if (!(isNumber || isOperator || isBracket)) {
+        else if (!(isNumber || isOperator || isBracket || isSpace)) {
           parseOutput.errorString = `Unknown word at position ${currentPosition}`;
           tokenClassName += " error";
           expectation = Expectation.UNDEFINED;
@@ -202,6 +206,9 @@ export class Parser {
         }
       }
 
+      if (token == "(") parentheses.push(currentPosition);
+      else if (token == ")") parentheses.pop();
+      
       formattedString = `${formattedString}${token}`;
 
       currentPosition += token.length;

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -246,6 +246,11 @@ export class Parser {
       parseOutput.recommendations = !parseOutput.errorString?.length ? Array.from(this.variables.keys()) : [];
     } 
     
+    //formula ends with mathematical operator
+    if (this.mathematicalOperators.has(previousToken)) {
+      parseOutput.errorString = `Unexpected ending with mathematical operator at position: ${currentPosition}`;
+    } 
+
     // formula has unclosed `(`
     if (!parentheses.isEmpty()) {
       parseOutput.errorString = `Unclosed '(' at position: ${parentheses.top()}`;
@@ -359,7 +364,7 @@ export class Parser {
       // and can be directly put into the result stack.
 
       if (
-        ((symbol === "+" || symbol[0] === "-") && this.variables.has(symbol.substring(1))) || 
+        ((symbol[0] === "+" || symbol[0] === "-") && this.variables.has(symbol.substring(1))) || 
         this.variables.has(symbol) ||
         (!isNaN(parseFloat(symbol)) && isFinite(parseFloat(symbol)))
       ) {

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -434,19 +434,11 @@ export class Parser {
     while (!rpn.isEmpty()) {
       const frontItem = rpn.dequeue()!;
       if (!this.mathematicalOperators.has(frontItem)) {
+        const [sign, variableKey] = /^[+-]/.test(frontItem) ? [frontItem[0], frontItem.slice(1)] : ["", frontItem];
+        const operandValue = Number.parseFloat(this.variables.get(variableKey)?.toString() ?? variableKey);
 
-        const sign =
-            frontItem[0] === "+" || frontItem[0] === "-" ? frontItem[0] : "";
-
-        const key = sign ? frontItem.substring(1) : frontItem;
-
-        const number = sign + (this.variables.get(key)?.toString() ?? key);
-
-        calcStack.push(
-          Big(
-            Number.parseFloat(number)
-          )
-        );
+        const number = Number.parseFloat(sign + "1") * operandValue;
+        calcStack.push(Big(number));
       } else {
         let operator = frontItem;
         let numB = calcStack.pop()!;

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -241,10 +241,13 @@ export class Parser {
       formattedString = `${formattedString}${recommendation}`;
     }
 
-    // If the formula ends with a mathematical operator, or has unclosed `(`
+    // formula ends with a mathematical operator
     if (this.mathematicalOperators.has(previousToken) || !previousToken.trim().length) {
-      parseOutput.recommendations = Array.from(this.variables.keys());
-    } else if (!parentheses.isEmpty()) {
+      parseOutput.recommendations = !parseOutput.errorString?.length ? Array.from(this.variables.keys()) : [];
+    } 
+    
+    // formula has unclosed `(`
+    if (!parentheses.isEmpty()) {
       parseOutput.errorString = `Unclosed '(' at position: ${parentheses.top()}`;
     }
 

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -131,7 +131,7 @@ export class Parser {
           recommendation = null;
         }
 
-        parseOutput.recommendations = this.mathematicalOperators.has(token) ? Array.from(this.variables.keys()) : this._recommender.getRecommendation(token);
+        parseOutput.recommendations = this._recommender.getRecommendation(token);
       }
 
       let tokenClassName = "";

--- a/packages/formula-editor/src/parser.ts
+++ b/packages/formula-editor/src/parser.ts
@@ -138,8 +138,14 @@ export class Parser {
 
       // Don't check for errors if an error has already been encountered.
       if (expectation != Expectation.UNDEFINED) {
+
+        if(this.mathematicalOperators.has(previousToken) && isOperator) {
+          parseOutput.errorString = `Unexpected same operator at position ${currentPosition}`;
+          expectation = Expectation.UNDEFINED;
+        }
+
         // Unnecessary closing parenthesis
-        if (parentheses.isEmpty() && token == ")") {
+        else if (parentheses.isEmpty() && token == ")") {
           parseOutput.errorString = `Unexpected ')' at position ${currentPosition}`;
           tokenClassName += " error";
           expectation = Expectation.UNDEFINED;
@@ -426,13 +432,18 @@ export class Parser {
 
     while (!rpn.isEmpty()) {
       const frontItem = rpn.dequeue()!;
-
       if (!this.mathematicalOperators.has(frontItem)) {
+
+        const sign =
+            frontItem[0] === "+" || frontItem[0] === "-" ? frontItem[0] : "";
+
+        const key = sign ? frontItem.substring(1) : frontItem;
+
+        const number = sign + (this.variables.get(key)?.toString() ?? key);
+
         calcStack.push(
           Big(
-            Number.parseFloat(
-              this.variables.get(frontItem)?.toString() ?? frontItem
-            )
+            Number.parseFloat(number)
           )
         );
       } else {

--- a/packages/formula-editor/src/styles/formula-editor-styles.ts
+++ b/packages/formula-editor/src/styles/formula-editor-styles.ts
@@ -9,9 +9,8 @@ export const FormulaEditorStyles = css`
   }
 
   #wysiwyg-editor {
-    display: inline-block;
-    resize: vertical;
-    overflow-y: auto;
+    display: block;
+    resize: none;
     padding: var(--fe-padding, 4px);
     caret-color: var(--fe-caret-color, #fff);
     color: var(--fe-text-color, #f7f1ff);

--- a/packages/formula-editor/src/styles/formula-editor-styles.ts
+++ b/packages/formula-editor/src/styles/formula-editor-styles.ts
@@ -31,4 +31,11 @@ export const FormulaEditorStyles = css`
     color: var(--fe-placeholder-color, grey);
     pointer-events: none;
   }
+
+  #wysiwyg-editor.error {
+    text-decoration: underline;
+    -webkit-text-decoration-style: wavy;
+    text-decoration-style: wavy;
+    text-decoration-color: var(--fe-err-underline-color, red);
+  }
 `;

--- a/packages/formula-editor/src/styles/formula-editor-styles.ts
+++ b/packages/formula-editor/src/styles/formula-editor-styles.ts
@@ -1,7 +1,6 @@
 import { css } from "lit";
 
 export const FormulaEditorStyles = css`
-
   .formula-editor-label {
     display: block;
     font-size: var(--fe-label-font-size, 0.8rem);
@@ -11,50 +10,26 @@ export const FormulaEditorStyles = css`
 
   #wysiwyg-editor {
     display: inline-block;
+    resize: vertical;
+    overflow-y: auto;
     padding: var(--fe-padding, 4px);
     caret-color: var(--fe-caret-color, #fff);
     color: var(--fe-text-color, #f7f1ff);
-    line-height: 1.1;
-    width:  var(--fe-width, 100%);
-    height: var(--fe-height, 60%);
+    font-size: var(--fe-text-font-size, 12px);
+    min-width: 100%;
+    min-height: 30px;
+    height: var(--fe-height, 30px);
     border-radius: var(--fe-border-radius, 4px);
-    overflow: auto;
     border: var(--fe-border, 2px solid black);
     border-bottom: var(--fe-border-bottom, 0px solid black);
     outline: 0px solid black;
-    white-space: pre-wrap;
     background-color: var(--fe-background-color, #222222);
-    margin: 0px;
     box-sizing: border-box;
-    /* position: relative; */
   }
 
   #wysiwyg-editor:empty:before {
-  content: attr(placeholder);
-  color: var(--fe-placeholder-color,grey);
-  pointer-events: none;
-  }
-
-  .wysiwygInternals.error {
-    text-decoration: underline;
-    -webkit-text-decoration-color: var(--fe-err-underline-color, #fc514f);
-    text-decoration-color: var(--fe-err-underline-color, #fc514f);
-    -webkit-text-decoration-style: wavy;
-    text-decoration-style: wavy;
-    /* text-decoration-thickness: 1px; */
-    text-decoration-color: var(--fe-err-underline-color, red);
-  }
-
-  .wysiwygInternals.bracket {
-    color: var(--fe-bracket-color, #fc514f);
-  }
-
-  .wysiwygInternals.operator {
-    font-weight: bold;
-    color: var(--fe-operator-color, #fc618d);
-  }
-
-  .wysiwygInternals.variable {
-    color: var(--fe-variable-color, #fc618d);
+    content: attr(placeholder);
+    color: var(--fe-placeholder-color, grey);
+    pointer-events: none;
   }
 `;


### PR DESCRIPTION
#### Description

- Use text area instead of div as formula input element
- Show recommendations only when user types any character (not any operator) in between the input string
- Show error in case of multiple operators in between formula string
- Handle calculation in case of any operator preceding any variable/number in formula string
