### PR TITLE
chore: optionally chain block related props

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.3.3-optionally-chain-props.0",
+  "version": "2.3.3-optionally-chain-props.1",
   "command": {
     "version": {
       "message": "chore(release): publish %s \n [skip ci]"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18077,10 +18077,10 @@
     },
     "packages/formula-editor": {
       "name": "@fw-components/formula-editor",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.3.2",
+        "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
         "big.js": "^6.2.1",
         "lit": "^2.1.2",
         "match-sorter": "^8.0.0",
@@ -18106,10 +18106,10 @@
     },
     "packages/fw-avatar": {
       "name": "@fw-components/fw-avatar",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.3.2",
+        "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-list": "^0.25.3",
         "@material/mwc-menu": "^0.25.3",
@@ -18128,10 +18128,10 @@
     },
     "packages/fw-dnd": {
       "name": "@fw-components/fw-dnd",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/styles": "^2.3.2",
+        "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
         "@polymer/iron-icons": "^3.0.1",
         "@polymer/paper-button": "^3.0.1",
         "@polymer/paper-icon-button": "^3.0.2",
@@ -18141,11 +18141,11 @@
     },
     "packages/fw-theme-builder": {
       "name": "@fw-components/fw-theme-builder",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
-        "@fw-components/localize": "^2.3.2",
-        "@fw-components/styles": "^2.3.2",
+        "@fw-components/localize": "^2.3.3-optionally-chain-props.0",
+        "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
         "@polymer/paper-dropdown-menu": "^3.2.0",
         "@polymer/paper-item": "^3.0.1",
         "@polymer/paper-listbox": "^3.0.1",
@@ -18171,7 +18171,7 @@
     },
     "packages/localize": {
       "name": "@fw-components/localize",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
         "@lit/localize": "0.12.2",
@@ -18201,7 +18201,7 @@
     },
     "packages/styles": {
       "name": "@fw-components/styles",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
         "lit": "^2.1.2"
@@ -18226,7 +18226,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18226,7 +18226,7 @@
     },
     "packages/trackers": {
       "name": "@fw-components/trackers",
-      "version": "2.3.3-optionally-chain-props.0",
+      "version": "2.3.3-optionally-chain-props.1",
       "license": "ISC",
       "dependencies": {
         "notion-utils": "^6.16.0"

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/formula-editor",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "A WYSIWYG type formula editor",
   "main": "dist/formula-editor/src/formula-editor.js",
   "exports": {
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@fw-components/styles": "^2.3.2",
+    "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
     "big.js": "^6.2.1",
     "lit": "^2.1.2",
     "match-sorter": "^8.0.0",

--- a/packages/fw-avatar/package.json
+++ b/packages/fw-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-avatar",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Avatar Web Component",
   "main": "src/fw-avatar.js",
   "type": "module",
@@ -15,7 +15,7 @@
     "test:watch": "web-test-runner  --watch"
   },
   "dependencies": {
-    "@fw-components/styles": "^2.3.2",
+    "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
     "@material/mwc-icon": "^0.27.0",
     "@material/mwc-list": "^0.25.3",
     "@material/mwc-menu": "^0.25.3",

--- a/packages/fw-dnd/package.json
+++ b/packages/fw-dnd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-dnd",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Drag-n-drop list",
   "main": "fw-dnd.js",
   "publishConfig": {
@@ -12,7 +12,7 @@
   "author": "The Fundwave Authors",
   "license": "ISC",
   "dependencies": {
-    "@fw-components/styles": "^2.3.2",
+    "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
     "@polymer/iron-icons": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-icon-button": "^3.0.2",

--- a/packages/fw-theme-builder/package-lock.json
+++ b/packages/fw-theme-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-theme-builder",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fw-theme-builder/package.json
+++ b/packages/fw-theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/fw-theme-builder",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Theme builder web component",
   "publishConfig": {
     "access": "public"
@@ -14,8 +14,8 @@
   "author": "The Fundwave Authors",
   "license": "ISC",
   "dependencies": {
-    "@fw-components/localize": "^2.3.2",
-    "@fw-components/styles": "^2.3.2",
+    "@fw-components/localize": "^2.3.3-optionally-chain-props.0",
+    "@fw-components/styles": "^2.3.3-optionally-chain-props.0",
     "@polymer/paper-dropdown-menu": "^3.2.0",
     "@polymer/paper-item": "^3.0.1",
     "@polymer/paper-listbox": "^3.0.1",

--- a/packages/localize/package-lock.json
+++ b/packages/localize/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fw-components/localize",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fw-components/localize",
-      "version": "2.3.2",
+      "version": "2.3.3-optionally-chain-props.0",
       "license": "ISC",
       "dependencies": {
         "@lit/localize": "0.12.2",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/localize",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Localizer built on top of lit-localize",
   "publishConfig": {
     "access": "public"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/styles",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Style library for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/lib/stores/notion.ts
+++ b/packages/trackers/lib/stores/notion.ts
@@ -19,7 +19,7 @@ export async function fetchEventsFromNotion(context: TStoreContext["notion"]) {
 
   const core = notionPage.block[pageId];
 
-  const collectionId = core?.value?.type === "collection_view_page" ? core.value.collection_id : null;
+  const collectionId = core?.value?.type === "collection_view_page" ? core.value?.collection_id : null;
 
   if (!collectionId) return;
 

--- a/packages/trackers/lib/stores/notion.ts
+++ b/packages/trackers/lib/stores/notion.ts
@@ -19,11 +19,11 @@ export async function fetchEventsFromNotion(context: TStoreContext["notion"]) {
 
   const core = notionPage.block[pageId];
 
-  const collectionId = core.value.type === "collection_view_page" ? core.value.collection_id : null;
+  const collectionId = core?.value?.type === "collection_view_page" ? core.value.collection_id : null;
 
   if (!collectionId) return;
 
-  const databaseProperties = notionPage.collection[collectionId].value.schema;
+  const databaseProperties = notionPage.collection?.[collectionId]?.value?.schema;
   if (!databaseProperties) return;
 
   const parsedEvents: IEvent[] = [];
@@ -38,6 +38,8 @@ export async function fetchEventsFromNotion(context: TStoreContext["notion"]) {
     const result: IEvent = { jsPath: "" };
 
     Object.entries(pageProperties).forEach(([property, value]) => {
+      if (!databaseProperties[property]) return;
+
       const key = databaseProperties[property].name as keyof IEvent;
 
       if (Array.isArray(value)) value = value.toString();

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.3.2",
+  "version": "2.3.3-optionally-chain-props.0",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"

--- a/packages/trackers/package.json
+++ b/packages/trackers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fw-components/trackers",
-  "version": "2.3.3-optionally-chain-props.0",
+  "version": "2.3.3-optionally-chain-props.1",
   "description": "Usage trackers for web components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
#### Description

stale properties (deleted from db) were seen on some notion pages

deleted property
<img width="671" height="658" alt="image" src="https://github.com/user-attachments/assets/ca9df7d4-4a85-4b3a-b6fe-17be8e5467fa" />

stale property on database page
<img width="439" height="323" alt="image" src="https://github.com/user-attachments/assets/31a6c31b-6a03-4d86-a1a4-7047a1914064" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Notion event tracking by safely handling missing or unexpected properties to prevent runtime errors.

* **Chores**
  * Bumped package versions across the monorepo to 2.3.3-optionally-chain-props (updated release metadata).
  * Updated component dependencies (styles, localize) to align with the bumped versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->